### PR TITLE
Add Worker pools

### DIFF
--- a/src/VoxelWorld.ts
+++ b/src/VoxelWorld.ts
@@ -339,10 +339,8 @@ export class World {
     const geometry = mesh ? mesh.geometry : new BufferGeometry();
 
     await chunkGeometryWorkerPool.queue(async (worker) => {
-      const logTime = new SimpleTimer();
       const { positions, normals, uvs, indices, lightValues } =
         await worker.generateGeometry(this.chunks, chunkCoordinates);
-      logTime.takenFor("running chunk geometry worker");
 
       const positionNumComponents = 3;
       geometry.setAttribute(

--- a/src/workers/workerPool.ts
+++ b/src/workers/workerPool.ts
@@ -1,0 +1,7 @@
+import { spawn, Pool, Worker } from "threads";
+
+const size = 8;
+export const chunkGeometryWorkerPool = Pool(
+  () => spawn(new Worker("./chunkGeometryWorker")),
+  size
+);

--- a/src/workers/workerPool.ts
+++ b/src/workers/workerPool.ts
@@ -1,7 +1,16 @@
 import { spawn, Pool, Worker } from "threads";
 
-const size = 8;
 export const chunkGeometryWorkerPool = Pool(
   () => spawn(new Worker("./chunkGeometryWorker")),
-  size
+  8
+);
+
+export const sunlightWorkerPool = Pool(
+  () => spawn(new Worker("./sunlightWorker")),
+  8
+);
+
+export const floodLightWorkerPool = Pool(
+  () => spawn(new Worker("./floodLightWorker")),
+  8
 );


### PR DESCRIPTION
This PR reduces the build time of the world by half because it removes the overhead of spawning a new thread and killing it for each chunk that gets computed. 

Instead, the game now uses three thread pools (geometry, floodlight, sunlight) and queues work to them, decreasing the chunk loading time for the initial scene from around 30 seconds down to 15 seconds on my development machine. 